### PR TITLE
fix: handle 1000+ contacts - raise fetch limit and chunk job lookups

### DIFF
--- a/src/lib/contacts.ts
+++ b/src/lib/contacts.ts
@@ -64,6 +64,7 @@ export async function getContactsLite(): Promise<Pick<Contact,
       .select('id,name,company,job_title,email,phone,current_location,linkedin_url,notes,mutual_connections,experience,education,created_at,updated_at,user_id')
       .eq('user_id', user.id)
       .order('created_at', { ascending: false })
+      .limit(5000)
 
     if (error) {
       console.error('Error fetching contacts (lite):', error)

--- a/src/lib/jobContacts.ts
+++ b/src/lib/jobContacts.ts
@@ -234,33 +234,41 @@ export async function getJobsForContacts(
       throw new Error('Auth session missing!')
     }
 
-    // Fetch all links for the provided contacts in a single query
-    const { data, error } = await supabase
-      .from('job_contacts')
-      .select(`
-        contact_id,
-        jobs (
-          id,
-          job_title,
-          company,
-          status,
-          location
-        )
-      `)
-      .in('contact_id', validContactIds)
-      .eq('user_id', user.id)
-
-    if (error) {
-      throw new Error(`Database error: ${error.message}`)
+    // Chunk IDs to avoid Supabase URL length limits (~500 per request)
+    const CHUNK_SIZE = 500
+    const chunks: string[][] = []
+    for (let i = 0; i < validContactIds.length; i += CHUNK_SIZE) {
+      chunks.push(validContactIds.slice(i, i + CHUNK_SIZE))
     }
 
     const map: Record<string, LinkedJob[]> = {}
-    for (const row of data || []) {
-      const cid = (row as any).contact_id as string
-      const job = (row as any).jobs as LinkedJob
-      if (!cid || !job) continue
-      if (!map[cid]) map[cid] = []
-      map[cid].push(job)
+    for (const chunk of chunks) {
+      const { data, error } = await supabase
+        .from('job_contacts')
+        .select(`
+          contact_id,
+          jobs (
+            id,
+            job_title,
+            company,
+            status,
+            location
+          )
+        `)
+        .in('contact_id', chunk)
+        .eq('user_id', user.id)
+
+      if (error) {
+        throw new Error(`Database error: ${error.message}`)
+      }
+
+      for (const row of data || []) {
+        const cid = (row as any).contact_id as string
+        const job = (row as any).jobs as LinkedJob
+        if (!cid || !job) continue
+        if (!map[cid]) map[cid] = []
+        map[cid].push(job)
+      }
     }
 
     return map


### PR DESCRIPTION
## Summary
- Adds `.limit(5000)` to `getContactsLite()` to work around Supabase's default 1000-row cap that was silently hiding older contacts from the UI
- Fixes `getJobsForContacts` Bad Request error by splitting contact ID arrays into 500-item chunks before querying `job_contacts`

## Test plan
- [ ] Contacts beyond position 1000 (e.g. Melvin Simms) now appear in the Network tab and search
- [ ] No `Database error: Bad Request` errors in the console on page load
- [ ] Job tags still appear on contact cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)