### PR TITLE
fix: quote LinkedIn URLs in n8n contact matching query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ All API routes follow consistent patterns:
 
 ### n8n Docker Image Notes
 - Pull from `docker.n8n.io/n8nio/n8n` (current registry) — `n8nio/n8n` on Docker Hub may lag months behind
-- Latest n8n image is **distroless** (no shell, no package manager) — installing tools requires multi-stage Docker build; see `n8n-automation/Dockerfile` for pattern
+- Latest n8n image is **distroless** (no shell, no package manager) — installing tools requires multi-stage Docker build; see `../job-tracker-private/n8n-automation/Dockerfile` for pattern
 - When rebuilding custom image after base image update: `docker compose build --pull --no-cache`
 
 ### n8n 2.x Breaking Changes (upgraded March 2026)

--- a/src/app/api/n8n/contacts/route.ts
+++ b/src/app/api/n8n/contacts/route.ts
@@ -86,10 +86,11 @@ export async function POST(request: NextRequest) {
     // Match against both trailing-slash and non-trailing-slash variants
     let existingContact = null
     if (formattedLinkedInUrl) {
+      const urlWithSlash = `${formattedLinkedInUrl}/`
       const { data: linkedInMatch } = await supabase
         .from('contacts')
         .select('*')
-        .or(`linkedin_url.eq.${formattedLinkedInUrl},linkedin_url.eq.${formattedLinkedInUrl}/`)
+        .or(`linkedin_url.eq."${formattedLinkedInUrl}",linkedin_url.eq."${urlWithSlash}"`)
         .limit(1)
 
       if (linkedInMatch && linkedInMatch.length > 0) {


### PR DESCRIPTION
## Summary
- Fixes a bug where the Supabase `.or()` query failed to match LinkedIn URLs containing special characters (`/`, `:`)
- The unquoted URL values caused silent query failure, so contact updates fell through to inserts instead of updating the existing record
- Also updates CLAUDE.md to reflect the `n8n-automation/` folder moving to `job-tracker-private/`

## Test plan
- [ ] Drop a resume PDF for an existing contact into `resumes/incoming/`
- [ ] Run the n8n workflow and confirm the existing contact record is updated (not duplicated)
- [ ] Verify LinkedIn URL matching works for both trailing-slash and non-trailing-slash variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)