### PR TITLE
fix: interaction date clears when editing

### DIFF
--- a/src/components/InteractionForm.tsx
+++ b/src/components/InteractionForm.tsx
@@ -150,7 +150,7 @@ export default function InteractionForm({ contactId, interaction, onSuccess, onC
   // Initialize form data with default values
   const [formData, setFormData] = useState(() => ({
     type: interaction?.type || 'email' as const,
-    date: interaction?.date || new Date().toISOString().split('T')[0],
+    date: interaction?.date ? interaction.date.split('T')[0] : new Date().toISOString().split('T')[0],
     summary: interaction?.summary || '',
     notes: interaction?.notes || ''
   }))


### PR DESCRIPTION
## Summary

- `interaction.date` is stored as `timestamptz` (e.g. `2026-05-15T09:00:00+00:00`)
- HTML `<input type="date">` only accepts `YYYY-MM-DD` — the browser silently rejects the full ISO string, leaving the field blank on every edit
- Fix: slice off the time component (`split('T')[0]`) when initializing the form state for an existing interaction

## Test plan

- [ ] Open an existing interaction for editing — date field should be pre-populated
- [ ] Save without changing the date — date should persist correctly
- [ ] Create a new interaction — date should default to today as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)