### PR TITLE
Fix: blocked senders reappearing in Detected card (email normalization)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-blocked-sender-email-normalization.md
+++ b/docs/superpowers/plans/2026-06-28-blocked-sender-email-normalization.md
@@ -1,0 +1,403 @@
+# Blocked-sender Email Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `counterparty_email` always a bare email so blocked senders are reliably suppressed from the Detected card, including retroactive cleanup of already-queued items.
+
+**Architecture:** Add a tested `parseEmailAddress` helper to the pure-logic layer (`src/lib/google-sync/identity.ts`), use it to normalize Gmail `From`/To/Cc parsing, normalize block patterns on write + retroactively sweep the queue in the review-queue API, and ship a one-time SQL migration that cleans existing dirty data. Pure logic is mirrored into the Edge Function's `_shared/` dir and parity is enforced by `scripts/check-vendored-sync.sh`.
+
+**Tech Stack:** TypeScript, Next.js App Router API routes, Supabase (PostgreSQL), Deno Edge Functions, Vitest.
+
+## Global Constraints
+
+- Pure logic in `src/lib/google-sync/*.ts` MUST be byte-identical to `supabase/functions/sync-google-interactions/_shared/*.ts`, except vendored copies import with `.ts` suffixes (`from './types.ts'`). Enforced by `scripts/check-vendored-sync.sh`, which runs first in `npm test`.
+- All emails compared after lowercasing + trimming.
+- Migrations: timestamped SQL in `supabase/migrations/`, applied via `supabase db push`. Next number is `0011`.
+- API routes verify ownership via `eq('user_id', user.id)` before any write.
+- Git commit messages end with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+
+---
+
+### Task 1: `parseEmailAddress` helper
+
+**Files:**
+- Modify: `src/lib/google-sync/identity.ts`
+- Modify: `supabase/functions/sync-google-interactions/_shared/identity.ts` (vendored copy — keep byte-identical modulo `.ts` import suffix)
+- Test: `src/lib/google-sync/__tests__/identity.test.ts`
+
+**Interfaces:**
+- Produces: `parseEmailAddress(raw: string): string` — extracts a bare lowercased email from a `Name <email>` header or bare string; strips a trailing `>`; returns `''` when no `@` is present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/lib/google-sync/__tests__/identity.test.ts` (update the import on line 2 to include `parseEmailAddress`):
+
+```ts
+import { normalizeEmail, isOwn, classifyDirection, parseEmailAddress } from '../identity'
+```
+
+Add a new describe block:
+
+```ts
+describe('parseEmailAddress', () => {
+  it('extracts bare email from a display-name header', () => {
+    expect(parseEmailAddress('Acme <hello@example.com>')).toBe('hello@example.com')
+  })
+  it('extracts from a quoted comma display name', () => {
+    expect(parseEmailAddress('"Doe, Jane" <jane.doe@example.com>'))
+      .toBe('jane.doe@example.com')
+  })
+  it('passes through a bare email lowercased and trimmed', () => {
+    expect(parseEmailAddress('  Ashley@Example.COM ')).toBe('ashley@example.com')
+  })
+  it('strips a trailing angle bracket', () => {
+    expect(parseEmailAddress('hello@example.com>')).toBe('hello@example.com')
+  })
+  it('returns empty string when there is no @', () => {
+    expect(parseEmailAddress('Some Name')).toBe('')
+  })
+  it('returns empty string for empty input', () => {
+    expect(parseEmailAddress('')).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/google-sync/__tests__/identity.test.ts`
+Expected: FAIL — `parseEmailAddress is not a function` / not exported.
+
+- [ ] **Step 3: Implement `parseEmailAddress` in `src/lib/google-sync/identity.ts`**
+
+Add after `normalizeEmail`:
+
+```ts
+export function parseEmailAddress(raw: string): string {
+  const m = raw.match(/<([^>]+)>/)
+  const candidate = (m ? m[1] : raw).trim().toLowerCase().replace(/>+$/, '')
+  return candidate.includes('@') ? candidate : ''
+}
+```
+
+- [ ] **Step 4: Mirror into the vendored copy**
+
+Add the identical function to `supabase/functions/sync-google-interactions/_shared/identity.ts` (this file uses `from './types.ts'` on line 1; the function body has no imports so it is byte-identical).
+
+- [ ] **Step 5: Run tests + drift check to verify they pass**
+
+Run: `npx vitest run src/lib/google-sync/__tests__/identity.test.ts && bash scripts/check-vendored-sync.sh`
+Expected: tests PASS; drift check prints nothing and exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/google-sync/identity.ts supabase/functions/sync-google-interactions/_shared/identity.ts src/lib/google-sync/__tests__/identity.test.ts
+git commit -m "feat: add parseEmailAddress helper for bare-email extraction
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Use `parseEmailAddress` in Gmail normalization
+
+**Files:**
+- Modify: `src/lib/google-sync/gmail.ts:37-43` (`parseAddrs`), `:61-66` (counterparty collection)
+- Modify: `supabase/functions/sync-google-interactions/_shared/gmail.ts` (vendored copy)
+- Test: `src/lib/google-sync/__tests__/gmail.test.ts`
+
+**Interfaces:**
+- Consumes: `parseEmailAddress` from Task 1.
+- Produces: `normalizeThread(...)` now sets `counterpartyEmail` to a bare email even when the `From` header carries a display name.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/google-sync/__tests__/gmail.test.ts` (inside the `describe('gmail', ...)` block):
+
+```ts
+it('extracts a bare counterparty email from a display-name From header', () => {
+  const t = {
+    id: 'thr2',
+    messages: [
+      { headers: { From: 'me@gmail.com', To: 'Acme <hello@example.com>', Subject: 'Q', Date: '2026-05-01T10:00:00Z' } },
+      { headers: { From: 'Acme <hello@example.com>', To: 'me@gmail.com', Subject: 'Re: Q', Date: '2026-05-02T10:00:00Z' } },
+    ],
+  }
+  const out = normalizeThread(t, identity)
+  expect(out).toHaveLength(1)
+  expect(out[0].counterpartyEmail).toBe('hello@example.com')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/google-sync/__tests__/gmail.test.ts -t "bare counterparty"`
+Expected: FAIL — `counterpartyEmail` is `'every <hello@example.com>'`, not `'hello@example.com'`.
+
+- [ ] **Step 3: Update `parseAddrs` and the counterparty collection in `src/lib/google-sync/gmail.ts`**
+
+Change the import on line 1 to add `parseEmailAddress`:
+
+```ts
+import { normalizeEmail, isOwn, classifyDirection, parseEmailAddress } from './identity'
+```
+
+Replace `parseAddrs` (lines 37-43) with:
+
+```ts
+function parseAddrs(v?: string): string[] {
+  if (!v) return []
+  return v.split(',').map(s => parseEmailAddress(s)).filter(Boolean)
+}
+```
+
+Replace the counterparty collection loop (lines 61-66) so the `From` header is parsed too:
+
+```ts
+  for (const m of sorted) {
+    const everyone = [
+      parseEmailAddress(m.headers.From),
+      ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
+    ]
+    for (const e of everyone) if (e && !isOwn(e, identity)) counterparties.add(e)
+  }
+```
+
+(Note: `isOwn`/`classifyDirection` still receive the raw `From` header elsewhere in the file — that is fine, `isOwn` already calls `normalizeEmail` and the noise/direction checks tolerate the wrapper. Leave lines 52 and 67 unchanged.)
+
+- [ ] **Step 4: Mirror into the vendored copy**
+
+Apply the identical edits to `supabase/functions/sync-google-interactions/_shared/gmail.ts` (its import line uses `from './identity.ts'`).
+
+- [ ] **Step 5: Run tests + drift check to verify they pass**
+
+Run: `npm test`
+Expected: drift check passes; all gmail + identity tests PASS, including the new one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/google-sync/gmail.ts supabase/functions/sync-google-interactions/_shared/gmail.ts src/lib/google-sync/__tests__/gmail.test.ts
+git commit -m "fix: parse bare counterparty email from Gmail From/To/Cc headers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Normalize block patterns on write + retroactive sweep
+
+**Files:**
+- Modify: `src/app/api/review-queue/[id]/route.ts:93-116` (the `dismiss` branch of `PATCH`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (the API route does not import the pure-logic layer; it inlines a small normalizer to avoid a server/edge bundling dependency).
+- Produces: dismiss-with-block stores a normalized pattern and dismisses already-queued matching rows.
+
+This task has no unit test harness for API routes in this repo (the existing tests are Vitest over pure logic only). Verification is via the live diagnostic SQL in Task 5. Implement carefully and commit.
+
+- [ ] **Step 1: Replace the `dismiss` branch in `src/app/api/review-queue/[id]/route.ts`**
+
+Replace the entire `if (body.action === 'dismiss') { ... }` block (lines 93-116) with:
+
+```ts
+  if (body.action === 'dismiss') {
+    if (body.patternType && !['sender', 'domain'].includes(body.patternType)) {
+      return NextResponse.json({ error: 'invalid patternType' }, { status: 400 })
+    }
+    await supa.from('interaction_review_queue')
+      .update({ status: 'dismissed' }).eq('id', id).eq('user_id', user.id)
+
+    if (body.blockPattern && body.patternType) {
+      // Normalize the pattern so it matches the bare counterparty_email values.
+      // sender: extract bare email from a possible "Name <email>" header.
+      // domain: strip brackets, leading @, and trailing '>'.
+      let safe: string
+      if (body.patternType === 'sender') {
+        const m = body.blockPattern.match(/<([^>]+)>/)
+        const bare = (m ? m[1] : body.blockPattern).trim().toLowerCase().replace(/>+$/, '')
+        safe = bare.includes('@') ? bare : body.blockPattern.trim().toLowerCase()
+      } else {
+        safe = body.blockPattern.trim().toLowerCase().replace(/[<>]/g, '').replace(/^@/, '')
+      }
+
+      if (body.patternType === 'domain' && safe.includes('@')) {
+        return NextResponse.json({ error: 'domain pattern must not include @' }, { status: 400 })
+      }
+
+      if (safe) {
+        const { error: insertErr } = await supa.from('blocked_senders').insert({
+          user_id: user.id,
+          pattern: safe,
+          pattern_type: body.patternType,
+        })
+        if (insertErr && insertErr.code !== '23505') {
+          console.error('blocked_senders insert failed:', insertErr.message)
+        }
+
+        // Retroactively dismiss already-queued items from this sender/domain.
+        // sender → exact match; domain → '%@<domain>' so 'example.com' doesn't
+        // match 'notexample.com'. Best-effort: log but don't fail the request.
+        let sweep = supa.from('interaction_review_queue')
+          .update({ status: 'dismissed' })
+          .eq('user_id', user.id)
+          .in('status', ['pending', 'skipped'])
+        sweep = body.patternType === 'sender'
+          ? sweep.eq('counterparty_email', safe)
+          : sweep.ilike('counterparty_email', `%@${safe}`)
+        const { error: sweepErr } = await sweep
+        if (sweepErr) console.error('block sweep failed:', sweepErr.message)
+      }
+    }
+    return NextResponse.json({ ok: true })
+  }
+```
+
+- [ ] **Step 2: Type-check the route**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors in `src/app/api/review-queue/[id]/route.ts`. (Pre-existing errors elsewhere are tolerated — confirm none are newly introduced in this file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/review-queue/[id]/route.ts
+git commit -m "feat: normalize block pattern on write and sweep queued matches
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: One-time data-cleanup migration
+
+**Files:**
+- Create: `supabase/migrations/0011_normalize_blocked_and_queue.sql`
+
+**Interfaces:**
+- Consumes: nothing. Pure SQL run against the live DB.
+- Produces: clean `counterparty_email` on all queue rows, normalized `blocked_senders` patterns, and dismissal of stale matching rows.
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/0011_normalize_blocked_and_queue.sql`:
+
+```sql
+-- 0011_normalize_blocked_and_queue.sql
+-- Fix dirty counterparty_email (raw "Name <email>" headers) and malformed
+-- blocked_senders patterns introduced before the parseEmailAddress fix, then
+-- retroactively dismiss already-queued items matching a block rule.
+-- Idempotent: re-running on already-clean data is a no-op.
+
+-- Helper: extract a bare lowercased email from a raw header-ish string.
+create or replace function pg_temp.bare_email(raw text) returns text as $$
+  select case
+    when raw ~ '<[^>]+>' then lower(trim(substring(raw from '<([^>]+)>')))
+    else regexp_replace(lower(trim(raw)), '>+$', '')
+  end;
+$$ language sql immutable;
+
+-- 1. Normalize queue counterparty_email to bare email.
+update interaction_review_queue
+set counterparty_email = pg_temp.bare_email(counterparty_email)
+where counterparty_email is not null
+  and counterparty_email <> pg_temp.bare_email(counterparty_email);
+
+-- 2. Normalize blocked_senders patterns.
+--    sender  → bare email
+--    domain  → strip brackets, leading @, trailing '>'
+update blocked_senders
+set pattern = pg_temp.bare_email(pattern)
+where pattern_type = 'sender'
+  and pattern <> pg_temp.bare_email(pattern);
+
+update blocked_senders
+set pattern = regexp_replace(replace(replace(lower(trim(pattern)), '<', ''), '>', ''), '^@', '')
+where pattern_type = 'domain'
+  and pattern <> regexp_replace(replace(replace(lower(trim(pattern)), '<', ''), '>', ''), '^@', '');
+
+-- 3. Drop unparseable / now-empty patterns and de-dup collisions.
+delete from blocked_senders
+where pattern is null or trim(pattern) = ''
+   or (pattern_type = 'sender' and pattern not like '%@%');
+
+-- De-dup: keep the earliest row per (user_id, pattern, pattern_type).
+delete from blocked_senders b
+using blocked_senders b2
+where b.user_id = b2.user_id
+  and b.pattern = b2.pattern
+  and b.pattern_type = b2.pattern_type
+  and b.created_at > b2.created_at;
+
+-- 4. Retroactively dismiss pending/skipped rows that now match a rule.
+update interaction_review_queue q
+set status = 'dismissed'
+where q.status in ('pending', 'skipped')
+  and (
+    exists (
+      select 1 from blocked_senders s
+      where s.user_id = q.user_id and s.pattern_type = 'sender'
+        and s.pattern = lower(trim(q.counterparty_email))
+    )
+    or exists (
+      select 1 from blocked_senders d
+      where d.user_id = q.user_id and d.pattern_type = 'domain'
+        and d.pattern = split_part(lower(trim(q.counterparty_email)), '@', 2)
+    )
+  );
+```
+
+- [ ] **Step 2: Apply the migration**
+
+Run: `supabase db push`
+Expected: migration `0011` applies without error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/0011_normalize_blocked_and_queue.sql
+git commit -m "feat: migration to normalize counterparty_email and block patterns
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Acceptance verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the acceptance query against the live DB**
+
+Run this SQL (via the Supabase MCP `execute_sql` against project `bpaffcxxhkxchyfhyrwg`):
+
+```sql
+with p as (
+  select id, lower(trim(counterparty_email)) as cpe
+  from interaction_review_queue where status = 'pending'
+),
+s as (select lower(trim(pattern)) pat from blocked_senders where pattern_type='sender'),
+d as (select lower(trim(pattern)) pat from blocked_senders where pattern_type='domain')
+select count(*) as still_leaking
+from p
+where exists (select 1 from s where s.pat = p.cpe)
+   or exists (select 1 from d where d.pat = split_part(p.cpe,'@',2));
+```
+
+Expected: `still_leaking = 0`.
+
+- [ ] **Step 2: Confirm pending count dropped and no clean emails were mangled**
+
+```sql
+select status, count(*) from interaction_review_queue group by status order by count desc;
+select counterparty_email from interaction_review_queue
+where counterparty_email like '%<%' or counterparty_email like '%>%' limit 10;
+```
+
+Expected: second query returns 0 rows (no remaining bracketed values).
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npm test`
+Expected: all tests pass; vendored-drift check passes.
+```

--- a/docs/superpowers/specs/2026-06-28-blocked-sender-email-normalization-design.md
+++ b/docs/superpowers/specs/2026-06-28-blocked-sender-email-normalization-design.md
@@ -1,0 +1,159 @@
+# Blocked-sender email normalization & retroactive sweep
+
+**Date:** 2026-06-28
+**Status:** Approved
+
+## Problem
+
+The Detected card in the Network tab surfaces conversations the user has
+already Blocked. Verified against live data (project `bpaffcxxhkxchyfhyrwg`):
+**18 pending `interaction_review_queue` rows are from senders/domains that
+already have a `blocked_senders` rule.**
+
+### Root cause
+
+`normalizeThread` in `src/lib/google-sync/gmail.ts` builds the counterparty
+list from message headers. The `From` header is pushed **raw** and only passed
+through `normalizeEmail` (which merely lowercases/trims — it does not extract
+the address from a `Name <email>` header):
+
+```ts
+const everyone = [
+  m.headers.From, ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
+].map(normalizeEmail)
+```
+
+So `counterpartyEmail` is stored as the full raw header, e.g.
+`every <hello@example.com>` instead of `hello@example.com`.
+
+This single bug cascades into three observable failures:
+
+1. **Dirty queue data** — `counterparty_email` holds `Name <email>`, not a
+   bare address.
+2. **Broken domain extraction** — `isBlocked()` does `email.split('@')[1]`,
+   which on `every <hello@example.com>` yields `example.com>` (trailing `>`).
+3. **Fragile blocking** — block rules captured from the same dirty source
+   sometimes match by coincidence (both sides equally broken) and sometimes
+   don't. A *clean* future email (`hello@example.com`) would NOT match a stored
+   sender pattern `every <hello@example.com>`, so blocked senders can leak back.
+
+Compounding this: blocking only filters at **insert time**. Rows already in
+the queue when a block rule is created are never re-evaluated, so even a
+correct match doesn't remove the backlog.
+
+## Goals
+
+- `counterparty_email` is always a bare, lowercased email address.
+- Block patterns are stored normalized (bare email for `sender`, clean domain
+  for `domain`) so matching is exact and predictable.
+- Dismiss-with-block retroactively dismisses already-queued items from the
+  same sender/domain.
+- Existing dirty data (queue rows + malformed patterns + 18 stale pending
+  rows) is cleaned up via a one-time migration.
+
+## Non-goals
+
+- Calendar normalization — `normalizeEvent` uses structured `attendee.email`
+  values, which are already bare addresses.
+- Changes to the noise-filter regex or confidence-gating logic.
+- Fuzzy/substring matching — explicitly rejected in favor of exact match on
+  normalized values.
+
+## Design
+
+### Part 1 — `parseEmailAddress` helper (`src/lib/google-sync/identity.ts`)
+
+New tested pure function:
+
+```ts
+export function parseEmailAddress(raw: string): string {
+  const m = raw.match(/<([^>]+)>/)
+  const candidate = (m ? m[1] : raw).trim().toLowerCase().replace(/>+$/, '')
+  return candidate.includes('@') ? candidate : ''
+}
+```
+
+Behavior:
+- `Name <e@x.com>` → `e@x.com`
+- `"Last, First" <e@x.com>` → `e@x.com`
+- `e@x.com` → `e@x.com`
+- `e@x.com>` → `e@x.com` (strips trailing `>`)
+- `Some Name` (no `@`) → `''`
+- `''` → `''`
+
+This lives in `identity.ts` (pure logic) and is **vendored** into the Edge
+Function's `_shared/` dir; `scripts/check-vendored-sync.sh` enforces parity.
+
+### Part 2 — Fix Gmail normalization (`src/lib/google-sync/gmail.ts`)
+
+Route the `From` header (and To/Cc, for consistency) through
+`parseEmailAddress` so `counterpartyEmail` is always a bare email. `parseAddrs`
+is updated to use `parseEmailAddress` instead of its inline regex +
+`normalizeEmail`.
+
+### Part 3 — Normalize block patterns on write (`src/app/api/review-queue/[id]/route.ts`, PATCH)
+
+When inserting into `blocked_senders`:
+- `sender` → store `parseEmailAddress(blockPattern)`; if it yields `''`, fall
+  back to the trimmed/lowercased input (preserves current behavior for odd
+  inputs rather than silently storing nothing).
+- `domain` → strip any `<>`, leading `@`, and trailing `>` to a clean domain;
+  keep the existing "must not include @" validation (applied after strip).
+
+### Part 4 — Retroactive sweep on dismiss-with-block
+
+After the block-rule insert succeeds, dismiss matching queued rows for the
+authenticated user:
+
+- `sender` → `.eq('counterparty_email', cleanEmail)` (post-migration the
+  column is bare, so exact match works).
+- `domain` → suffix match on `@<domain>`. Use `.ilike('counterparty_email',
+  '%@' + domain)` — the `@` anchor prevents `example.com` from matching
+  `notexample.com`.
+- Scope: `.in('status', ['pending', 'skipped']).eq('user_id', user.id)`.
+
+Best-effort: log on error, don't fail the request (the block rule already
+persisted and the primary row is already dismissed).
+
+### Part 5 — One-time data-cleanup migration (`supabase/migrations/0011_normalize_blocked_and_queue.sql`)
+
+1. **Queue:** rewrite `counterparty_email` to bare email for all rows —
+   regex-extract `<...>` when present, else strip a trailing `>`, lowercase,
+   trim.
+2. **Patterns:** normalize `blocked_senders.pattern` the same way (bare email
+   for `sender`, clean domain for `domain`). Dedup collisions — the
+   `blocked_senders_user_pattern_uidx` unique index already prevents
+   duplicates; the migration rebuilds via an upsert/dedup CTE and drops rows
+   that normalize to an empty/invalid value (logged via `RAISE NOTICE`).
+3. **Stale sweep:** set `status = 'dismissed'` on `pending`/`skipped` queue
+   rows whose (now-clean) `counterparty_email` matches any normalized
+   `blocked_senders` rule for the same user.
+
+The migration is idempotent (safe to re-run; normalizing an already-bare value
+is a no-op).
+
+## Testing (TDD)
+
+- **`identity.test.ts`** — `parseEmailAddress`: display-name header, quoted
+  comma display name, bare email, trailing `>`, no-`@` → `''`, empty string.
+- **`gmail.test.ts`** — `normalizeThread` produces a bare `counterpartyEmail`
+  when `From` carries a display name.
+- **Migration / API verification** — re-run the diagnostic SQL after applying:
+  expect **0** `pending` rows whose `counterparty_email` matches a
+  `blocked_senders` rule.
+
+## Verification query (acceptance)
+
+```sql
+with p as (
+  select id, lower(trim(counterparty_email)) as cpe
+  from interaction_review_queue where status = 'pending'
+),
+s as (select lower(trim(pattern)) pat from blocked_senders where pattern_type='sender'),
+d as (select lower(trim(pattern)) pat from blocked_senders where pattern_type='domain')
+select count(*) as still_leaking
+from p
+where exists (select 1 from s where s.pat = p.cpe)
+   or exists (select 1 from d where d.pat = split_part(p.cpe,'@',2));
+-- expect 0
+```

--- a/src/app/api/review-queue/[id]/route.ts
+++ b/src/app/api/review-queue/[id]/route.ts
@@ -96,11 +96,24 @@ export async function PATCH(req: Request,
     }
     await supa.from('interaction_review_queue')
       .update({ status: 'dismissed' }).eq('id', id).eq('user_id', user.id)
+
     if (body.blockPattern && body.patternType) {
-      const safe = body.blockPattern.trim().toLowerCase()
+      // Normalize the pattern so it matches the bare counterparty_email values.
+      // sender: extract bare email from a possible "Name <email>" header.
+      // domain: strip brackets, leading @, and trailing '>'.
+      let safe: string
+      if (body.patternType === 'sender') {
+        const m = body.blockPattern.match(/<([^>]+)>/)
+        const bare = (m ? m[1] : body.blockPattern).trim().toLowerCase().replace(/>+$/, '')
+        safe = bare.includes('@') ? bare : body.blockPattern.trim().toLowerCase()
+      } else {
+        safe = body.blockPattern.trim().toLowerCase().replace(/[<>]/g, '').replace(/^@/, '')
+      }
+
       if (body.patternType === 'domain' && safe.includes('@')) {
         return NextResponse.json({ error: 'domain pattern must not include @' }, { status: 400 })
       }
+
       if (safe) {
         const { error: insertErr } = await supa.from('blocked_senders').insert({
           user_id: user.id,
@@ -110,6 +123,19 @@ export async function PATCH(req: Request,
         if (insertErr && insertErr.code !== '23505') {
           console.error('blocked_senders insert failed:', insertErr.message)
         }
+
+        // Retroactively dismiss already-queued items from this sender/domain.
+        // sender → exact match; domain → '%@<domain>' so 'example.com' doesn't
+        // match 'notexample.com'. Best-effort: log but don't fail the request.
+        let sweep = supa.from('interaction_review_queue')
+          .update({ status: 'dismissed' })
+          .eq('user_id', user.id)
+          .in('status', ['pending', 'skipped'])
+        sweep = body.patternType === 'sender'
+          ? sweep.eq('counterparty_email', safe)
+          : sweep.ilike('counterparty_email', `%@${safe}`)
+        const { error: sweepErr } = await sweep
+        if (sweepErr) console.error('block sweep failed:', sweepErr.message)
       }
     }
     return NextResponse.json({ ok: true })

--- a/src/lib/google-sync/__tests__/gmail.test.ts
+++ b/src/lib/google-sync/__tests__/gmail.test.ts
@@ -111,4 +111,16 @@ describe('gmail', () => {
     }
     expect(normalizeThread(t, identity)).toHaveLength(1)
   })
+  it('extracts a bare counterparty email from a display-name From header', () => {
+    const t = {
+      id: 'thr2',
+      messages: [
+        { headers: { From: 'me@gmail.com', To: 'Acme <hello@example.com>', Subject: 'Q', Date: '2026-05-01T10:00:00Z' } },
+        { headers: { From: 'Acme <hello@example.com>', To: 'me@gmail.com', Subject: 'Re: Q', Date: '2026-05-02T10:00:00Z' } },
+      ],
+    }
+    const out = normalizeThread(t, identity)
+    expect(out).toHaveLength(1)
+    expect(out[0].counterpartyEmail).toBe('hello@example.com')
+  })
 })

--- a/src/lib/google-sync/__tests__/identity.test.ts
+++ b/src/lib/google-sync/__tests__/identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeEmail, isOwn, classifyDirection } from '../identity'
+import { normalizeEmail, isOwn, classifyDirection, parseEmailAddress } from '../identity'
 
 const identity = new Set(['me@gmail.com', 'me@kinetic.com'])
 
@@ -16,5 +16,27 @@ describe('identity', () => {
   })
   it('classifies inbound when from is not own', () => {
     expect(classifyDirection('them@x.com', identity)).toBe('inbound')
+  })
+})
+
+describe('parseEmailAddress', () => {
+  it('extracts bare email from a display-name header', () => {
+    expect(parseEmailAddress('Acme <hello@example.com>')).toBe('hello@example.com')
+  })
+  it('extracts from a quoted comma display name', () => {
+    expect(parseEmailAddress('"Doe, Jane" <jane.doe@example.com>'))
+      .toBe('jane.doe@example.com')
+  })
+  it('passes through a bare email lowercased and trimmed', () => {
+    expect(parseEmailAddress('  Ashley@Example.COM ')).toBe('ashley@example.com')
+  })
+  it('strips a trailing angle bracket', () => {
+    expect(parseEmailAddress('hello@example.com>')).toBe('hello@example.com')
+  })
+  it('returns empty string when there is no @', () => {
+    expect(parseEmailAddress('Some Name')).toBe('')
+  })
+  it('returns empty string for empty input', () => {
+    expect(parseEmailAddress('')).toBe('')
   })
 })

--- a/src/lib/google-sync/gmail.ts
+++ b/src/lib/google-sync/gmail.ts
@@ -1,4 +1,4 @@
-import { normalizeEmail, isOwn, classifyDirection } from './identity'
+import { normalizeEmail, isOwn, classifyDirection, parseEmailAddress } from './identity'
 import type { NormalizedInteraction } from './types'
 
 const NOISE = /(^|[._-])(no-?reply|noreply|notifications?|donotreply|digest|alerts?|weekly|monthly|newsletter)@|@(lever\.co|greenhouse\.io|workday\.com|myworkday\.com|jobvite\.com|smartrecruiters\.com|taleo\.net|icims\.com|substack\.com|mailchimp\.com|sendgrid\.net|campaign-archive\.com|constantcontact\.com|klaviyo\.com|beehiiv\.com)/i
@@ -36,10 +36,7 @@ function extractPlainText(part: RawPart): string {
 
 function parseAddrs(v?: string): string[] {
   if (!v) return []
-  return v.split(',').map(s => {
-    const m = s.match(/<([^>]+)>/)
-    return normalizeEmail(m ? m[1] : s)
-  })
+  return v.split(',').map(s => parseEmailAddress(s)).filter(Boolean)
 }
 
 export function normalizeThread(
@@ -60,9 +57,10 @@ export function normalizeThread(
   const counterparties = new Set<string>()
   for (const m of sorted) {
     const everyone = [
-      m.headers.From, ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
-    ].map(normalizeEmail)
-    for (const e of everyone) if (!isOwn(e, identity) && e) counterparties.add(e)
+      parseEmailAddress(m.headers.From),
+      ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
+    ]
+    for (const e of everyone) if (e && !isOwn(e, identity)) counterparties.add(e)
   }
   const lastDir = classifyDirection(last.headers.From, identity)
   const lastAt = new Date(last.headers.Date).toISOString()

--- a/src/lib/google-sync/identity.ts
+++ b/src/lib/google-sync/identity.ts
@@ -4,6 +4,12 @@ export function normalizeEmail(raw: string): string {
   return raw.trim().toLowerCase()
 }
 
+export function parseEmailAddress(raw: string): string {
+  const m = raw.match(/<([^>]+)>/)
+  const candidate = (m ? m[1] : raw).trim().toLowerCase().replace(/>+$/, '')
+  return candidate.includes('@') ? candidate : ''
+}
+
 export function isOwn(email: string, identity: Set<string>): boolean {
   return identity.has(normalizeEmail(email))
 }

--- a/supabase/functions/sync-google-interactions/_shared/gmail.ts
+++ b/supabase/functions/sync-google-interactions/_shared/gmail.ts
@@ -1,4 +1,4 @@
-import { normalizeEmail, isOwn, classifyDirection } from './identity.ts'
+import { normalizeEmail, isOwn, classifyDirection, parseEmailAddress } from './identity.ts'
 import type { NormalizedInteraction } from './types.ts'
 
 const NOISE = /(^|[._-])(no-?reply|noreply|notifications?|donotreply|digest|alerts?|weekly|monthly|newsletter)@|@(lever\.co|greenhouse\.io|workday\.com|myworkday\.com|jobvite\.com|smartrecruiters\.com|taleo\.net|icims\.com|substack\.com|mailchimp\.com|sendgrid\.net|campaign-archive\.com|constantcontact\.com|klaviyo\.com|beehiiv\.com)/i
@@ -36,10 +36,7 @@ function extractPlainText(part: RawPart): string {
 
 function parseAddrs(v?: string): string[] {
   if (!v) return []
-  return v.split(',').map(s => {
-    const m = s.match(/<([^>]+)>/)
-    return normalizeEmail(m ? m[1] : s)
-  })
+  return v.split(',').map(s => parseEmailAddress(s)).filter(Boolean)
 }
 
 export function normalizeThread(
@@ -60,9 +57,10 @@ export function normalizeThread(
   const counterparties = new Set<string>()
   for (const m of sorted) {
     const everyone = [
-      m.headers.From, ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
-    ].map(normalizeEmail)
-    for (const e of everyone) if (!isOwn(e, identity) && e) counterparties.add(e)
+      parseEmailAddress(m.headers.From),
+      ...parseAddrs(m.headers.To), ...parseAddrs(m.headers.Cc),
+    ]
+    for (const e of everyone) if (e && !isOwn(e, identity)) counterparties.add(e)
   }
   const lastDir = classifyDirection(last.headers.From, identity)
   const lastAt = new Date(last.headers.Date).toISOString()

--- a/supabase/functions/sync-google-interactions/_shared/identity.ts
+++ b/supabase/functions/sync-google-interactions/_shared/identity.ts
@@ -4,6 +4,12 @@ export function normalizeEmail(raw: string): string {
   return raw.trim().toLowerCase()
 }
 
+export function parseEmailAddress(raw: string): string {
+  const m = raw.match(/<([^>]+)>/)
+  const candidate = (m ? m[1] : raw).trim().toLowerCase().replace(/>+$/, '')
+  return candidate.includes('@') ? candidate : ''
+}
+
 export function isOwn(email: string, identity: Set<string>): boolean {
   return identity.has(normalizeEmail(email))
 }

--- a/supabase/migrations/0011_normalize_blocked_and_queue.sql
+++ b/supabase/migrations/0011_normalize_blocked_and_queue.sql
@@ -1,0 +1,63 @@
+-- 0011_normalize_blocked_and_queue.sql
+-- Fix dirty counterparty_email (raw "Name <email>" headers) and malformed
+-- blocked_senders patterns introduced before the parseEmailAddress fix, then
+-- retroactively dismiss already-queued items matching a block rule.
+-- Idempotent: re-running on already-clean data is a no-op.
+
+-- Helper: extract a bare lowercased email from a raw header-ish string.
+create or replace function pg_temp.bare_email(raw text) returns text as $$
+  select case
+    when raw ~ '<[^>]+>' then lower(trim(substring(raw from '<([^>]+)>')))
+    else regexp_replace(lower(trim(raw)), '>+$', '')
+  end;
+$$ language sql immutable;
+
+-- 1. Normalize queue counterparty_email to bare email.
+update interaction_review_queue
+set counterparty_email = pg_temp.bare_email(counterparty_email)
+where counterparty_email is not null
+  and counterparty_email <> pg_temp.bare_email(counterparty_email);
+
+-- 2. Normalize blocked_senders patterns.
+--    sender  → bare email
+--    domain  → strip brackets, leading @, trailing '>'
+update blocked_senders
+set pattern = pg_temp.bare_email(pattern)
+where pattern_type = 'sender'
+  and pattern <> pg_temp.bare_email(pattern);
+
+update blocked_senders
+set pattern = regexp_replace(replace(replace(lower(trim(pattern)), '<', ''), '>', ''), '^@', '')
+where pattern_type = 'domain'
+  and pattern <> regexp_replace(replace(replace(lower(trim(pattern)), '<', ''), '>', ''), '^@', '');
+
+-- 3. Drop unparseable / now-empty patterns and de-dup collisions.
+delete from blocked_senders
+where pattern is null or trim(pattern) = ''
+   or (pattern_type = 'sender' and pattern not like '%@%');
+
+-- De-dup: keep the earliest row per (user_id, pattern, pattern_type).
+delete from blocked_senders b
+using blocked_senders b2
+where b.user_id = b2.user_id
+  and b.pattern = b2.pattern
+  and b.pattern_type = b2.pattern_type
+  and (b.created_at > b2.created_at
+       or (b.created_at = b2.created_at and b.ctid > b2.ctid));
+
+-- 4. Retroactively dismiss pending/skipped rows that now match a rule.
+update interaction_review_queue q
+set status = 'dismissed'
+where q.status in ('pending', 'skipped')
+  and (
+    exists (
+      select 1 from blocked_senders s
+      where s.user_id = q.user_id and s.pattern_type = 'sender'
+        and s.pattern = lower(trim(q.counterparty_email))
+    )
+    or exists (
+      select 1 from blocked_senders d
+      where d.user_id = q.user_id and d.pattern_type = 'domain'
+        and d.pattern = split_part(lower(trim(q.counterparty_email)), '@', 2)
+    )
+  );


### PR DESCRIPTION
## Problem

The Detected card surfaced conversations the user had already **Blocked**. Verified against live data: 18 pending `interaction_review_queue` rows were from senders/domains with an existing `blocked_senders` rule.

**Root cause:** `normalizeThread` (`gmail.ts`) pushed the raw `From` header (`Acme <hello@example.com>`) into `counterparty_email` and only lowercased it — `normalizeEmail` never extracted the `<email>`. This cascaded into dirty queue data, a broken `split('@')[1]` domain (`example.com>` with trailing `>`), and block rules that only matched by coincidence. Compounding it, blocking only filtered at insert time, so already-queued items were never swept.

## Changes

1. **`parseEmailAddress` helper** (`identity.ts` + vendored `_shared/` copy) — extracts a bare lowercased email from `Name <email>` headers; unit-tested.
2. **Gmail normalization** uses it for `From`/`To`/`Cc`, so `counterparty_email` is always a bare email.
3. **Review-queue API** (`route.ts`) normalizes the block pattern on write and **retroactively dismisses** already-queued `pending`/`skipped` rows from the same sender/domain (domain match is `@`-anchored so `example.com` ≠ `notexample.com`).
4. **Migration `0011`** — one-time cleanup: rewrites all `counterparty_email` to bare email, normalizes/dedups malformed `blocked_senders` patterns (deterministic `ctid` tie-break), and sweeps stale matching rows.

## Verification

- **Migration already applied to the live DB** and verified: `still_leaking = 0` (was 18); pending dropped 47 → 28; no bracketed `Name <email>` values remain.
- All 54 unit tests pass; vendored-drift check passes.
- Per-task reviews + full whole-branch review (Opus) — clean.

## ⚠️ Follow-up: Edge Function deploy

The Netlify deploy ships the Next.js app (API route + helper) but **not** the Supabase Edge Function. The new-thread normalization only takes effect in the daily sync after:

```
supabase functions deploy sync-google-interactions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)